### PR TITLE
#164798198 Documenting API with swagger

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ coverage = "*"
 gunicorn = "*"
 django-heroku = "*"
 pipenv-to-requirements = "*"
+django-rest-swagger = "*"
 
 [requires]
 python_version = "3.6.5"

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -1,5 +1,5 @@
 from rest_framework import status
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import RetrieveUpdateAPIView, GenericAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -10,7 +10,7 @@ from .serializers import (
 )
 
 
-class RegistrationAPIView(APIView):
+class RegistrationAPIView(GenericAPIView):
     # Allow any user (authenticated or not) to hit this endpoint.
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
@@ -28,7 +28,7 @@ class RegistrationAPIView(APIView):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
-class LoginAPIView(APIView):
+class LoginAPIView(GenericAPIView):
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = LoginSerializer

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -38,11 +38,10 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-
     'corsheaders',
     'django_extensions',
     'rest_framework',
-
+    'rest_framework_swagger',    
     'authors.apps.authentication',
     'authors.apps.core',
     'authors.apps.profiles',
@@ -143,5 +142,14 @@ REST_FRAMEWORK = {
     # 'DEFAULT_AUTHENTICATION_CLASSES': (
     #     'authors.apps.authentication.backends.JWTAuthentication',
     # ),
+}
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'api_key': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'Authorization'
+        }
+    },
 }
 django_heroku.settings(locals()) 

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -1,11 +1,14 @@
 from django.urls import include, path
 from django.contrib import admin
+from rest_framework_swagger.views import get_swagger_view
+
+schema_view = get_swagger_view(title="Authors' Haven")
 
 app_name = "Authors' Haven"
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-
+    path('swagger-docs/', schema_view),
     path('api/', include('authors.apps.authentication.urls')),
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,17 +10,4 @@
 # `Pipfile.lock` and then regenerate `requirements*.txt`.
 ################################################################################
 
-coverage
-coveralls
-dj-database-url
-django
-django-cors-headers
-django-extensions
-django-heroku
-django-rest-swagger
-djangorestframework
-gunicorn
-jwt
-pipenv-to-requirements
-psycopg2-binary
-python-decouple
+pylint


### PR DESCRIPTION
**What does this PR do?**

- API documentation with swagger

**Description of Task to be completed?**

- Install django-rest-swagger
- Add url to the documentation in the main urls file
- Add rest_framework_swagger to installed apps in the settings file

**How should this be manually tested?**

-  Fetch the branch `git fetch origin ft-document-api-164798198`
-  Checkout the branch `git checkout ft-document-api-164798198`
-  Run `pipenv install`  to install the required packages
-  Run the command`python manage.py runserver`
-  http://127.0.0.1:8000/swagger-docs/

**What are the relevant pivotal tracker stories?**

- [#164798198](https://www.pivotaltracker.com/n/projects/2320796/stories/164798198)

**Screenshots**

<img width="1438" alt="Screenshot 2019-03-28 at 17 24 43" src="https://user-images.githubusercontent.com/40162086/55178961-82548700-5197-11e9-81cc-dde030970cd2.png">
**

