### PR TITLE
#164798202 Password Reset with Email

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -11,6 +11,11 @@ from google.auth.transport import requests
 
 from .models import User
 from .social_registration import register_social_user
+from django.core.mail import EmailMessage
+from django.contrib.sites.shortcuts import get_current_site
+from django.shortcuts import get_object_or_404
+
+
 
 class RegistrationSerializer(serializers.ModelSerializer):
     """Serializers registration requests and creates a new user."""
@@ -214,6 +219,35 @@ class UserSerializer(serializers.ModelSerializer):
 
         return instance
 
+class ResetPasswordSerializer(serializers.Serializer):
+
+    email = serializers.EmailField(allow_blank=False)
+
+    def validate_email(self, data):
+        email = data.get('email', None)
+        if email is None:
+            raise serializers.ValidationError(
+                'Email is required'
+                )
+        return data
+
+class ConfirmPasswordSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(
+        max_length=128,
+        min_length=8,
+        write_only=True
+    )
+
+    confirm_password = serializers.CharField(
+        max_length=128,
+        min_length=8,
+        write_only=True
+    )
+    class Meta:
+        model = User
+        fields = ('password','confirm_password')
+
+    
 class SocialAuthSerializer(serializers.Serializer):
     """
     Social Authentication parent class

--- a/authors/apps/authentication/tests/test_data.py
+++ b/authors/apps/authentication/tests/test_data.py
@@ -153,3 +153,24 @@ social_reg_data = {
     'email': 'test@testmail.com',
     'username': 'testname'
 }
+reset_data = {
+	"email": "testuser2@gmail.com",
+}
+wrong_reset_email ={
+    "email": "test_user2@gmail.com"
+}
+
+password_reset_data = {
+	"user":{
+		"password":"asiimweD1",
+		"confirm_password":"asiimweD1"
+		
+	}
+}
+unmatched_password = {
+    "user":{
+		"password":"asiimweD1",
+		"confirm_password":"asiimeeeeee"
+		
+	}
+}

--- a/authors/apps/authentication/tests/test_password_reset.py
+++ b/authors/apps/authentication/tests/test_password_reset.py
@@ -1,0 +1,62 @@
+"""
+Module to test password reset
+"""
+from unittest.mock import patch
+from rest_framework import status
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from .test_base import BaseTestCase
+from .test_data import test_user_data, reset_data, login_data, password_reset_data, unmatched_password, wrong_reset_email
+
+
+class TestPasswordReset(BaseTestCase):
+    """
+    class to handle user password reset
+    """
+    def test_reset_email_link_sent(self):
+
+        self.client.post(reverse('register-user'),
+            data=test_user_data,
+            format='json')
+        response = self.client.post(reverse('reset-password'), 
+            data=reset_data,
+            format='json')
+        self.assertEquals(response.status_code,status.HTTP_200_OK)
+        self.assertEquals(response.data['message'],'Password reset link has been sent to your Email')
+
+    def test_reset_email_does_not_exist(self):
+
+        self.client.post(reverse('register-user'),
+            data=test_user_data,
+            format='json')
+        response = self.client.post(reverse('reset-password'), 
+            data=wrong_reset_email,
+            format='json')
+        self.assertEquals(response.status_code,status.HTTP_400_BAD_REQUEST)
+        self.assertEquals(response.data['message'],"Email does not exist")
+
+    def test_password_reset(self):
+
+        res = self.client.post(reverse('register-user'),
+            data=test_user_data,
+            format='json')
+        token = res.data["token"]
+        response = self.client.put(reverse('password-change', kwargs={'token':token}), 
+            data=password_reset_data,
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['message'], "Password has been reset")      
+    
+    def test_password_not_matching(self):
+      
+        res =  self.client.post(reverse('register-user'),
+            data=test_user_data,
+            format='json')
+        token = res.data["token"]
+        response = self.client.put(reverse('password-change', kwargs={'token':token}), 
+            data=unmatched_password,
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'], "Passwords do not match") 
+    
+

--- a/authors/apps/authentication/tests/test_serializer.py
+++ b/authors/apps/authentication/tests/test_serializer.py
@@ -1,6 +1,6 @@
 from .test_base import BaseTestCase
 from authors.apps.authentication.serializers import (
-    LoginSerializer, UserSerializer
+    LoginSerializer, UserSerializer, ResetPasswordSerializer
 )
 from unittest.mock import patch, MagicMock, PropertyMock
 
@@ -109,4 +109,11 @@ class TestLoginSerializer(BaseTestCase):
 
         class_instance = UpdateUserInstance()
         self.assertEqual(UserSerializer().update(class_instance, data_to_update_user), class_instance)
-
+    
+    def test_email_not_provided_for_password_reset(self): 
+        no_email_data = { 
+            "email":None
+        } 
+        with self.assertRaises(ValidationError) as e: 
+            ResetPasswordSerializer().validate_email(no_email_data) 
+        self.assertEqual(e.exception.args[0], 'Email is required')

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -3,7 +3,8 @@ from django.urls import path
 from .views import (
     LoginAPIView, RegistrationAPIView, 
     UserRetrieveUpdateAPIView, FacebookAuthApiView, 
-    GoogleAuthApiView, TwitterAuthApiView, VerifyUserAPIView, FavoritesList
+    GoogleAuthApiView, TwitterAuthApiView, VerifyUserAPIView, FavoritesList,
+    PasswordChangeView,PasswordResetView
 )
 
 urlpatterns = [
@@ -15,4 +16,7 @@ urlpatterns = [
     path('users/login/twitter', TwitterAuthApiView.as_view(), name='twitter'),
     path('users/verify/', VerifyUserAPIView.as_view(), name='verify-user'),
     path('users/articles/favorites', FavoritesList.as_view(), name='favorites'),
+    path('users/password-reset/', PasswordResetView.as_view(), name='reset-password'),
+    path('users/reset/<str:token>/change/', PasswordChangeView.as_view(), name='password-change')
+
 ]


### PR DESCRIPTION

**What does this PR do?**

- Resets users password via email

**How should this be manually tested?**

- fetch the branch to your remote workspace
- Run the server using `python manage.py runserver`
- The user puts in his email into the email field with POST  /api/users/password-reset/
- example of the body 
`{"user": 
      {"email": "dorothy.asiimwe@gmail.com"}
  }`
- An email is sent to the user with the password reset link.
- on Clicking the link, the user is able to reset the password using 
 PUT /users/reset/<str:token>/change/' with the body as below;
`{
    "user":{
    "password": "AssimweD1"
    "confirm_password":"AssimweD1"
     }
}`

**What are the relevant Pivotal Tracker stories**
[#164798202](https://www.pivotaltracker.com/n/projects/2320796/stories/164798202)
