### PR TITLE
fix(Get articles By Date) - Articles created lates should be returned…

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -26,7 +26,7 @@ class ListCreateArticle(generics.ListCreateAPIView):
     """
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
-    queryset = Article.objects.all()
+    queryset = Article.objects.all().order_by('-createdAt')
     serializer_class = serializers.ArticleSerializer
     pagination_class = ArticlePageNumberPagination
     search_fields = ('author__username', 'title', 'description', 'body', 'tags')


### PR DESCRIPTION
#### What does this PR do?

-  When getting articles, they should be ordered by creation date

#### How should this be manually tested?
- Fetch this branch `git fetch origin fix-get-articles-by-created-date`
- Checkout to the branch `git checkout fix-get-articles-by-created-date`
- Run `python manage.py runserver`
- Hit the endpoint to get all articles `api/articles/`

